### PR TITLE
WOB-540 Add functionality to automatically close the notification window

### DIFF
--- a/project/application/package.json
+++ b/project/application/package.json
@@ -34,6 +34,7 @@
     "redux": "4.0.1",
     "redux-thunk": "2.3.0",
     "socket.io-client": "2.2.0",
+    "uuid": "3.3.3",
     "yup": "0.27.0"
   },
   "devDependencies": {

--- a/project/application/src/App.js
+++ b/project/application/src/App.js
@@ -24,6 +24,7 @@ import './App.scss';
 import './fonts/icomoon/icomoon.css';
 
 import * as responsiveActions from './actions/ResponsiveActions';
+import { showNotificationAction } from './actions/NotificationActions';
 
 const addEvent = (object, type, callback) => {
     if (object === null || typeof object === 'undefined') return false;
@@ -53,13 +54,35 @@ class App extends Component {
         }
     };
 
+    connectionRestore = () => {
+        const { vocabulary, showNotificationAction } = this.props;
+        const { v_connection_restored } = vocabulary;
+        showNotificationAction({
+            type: 'connection-restored',
+            text: v_connection_restored,
+        });
+    };
+
+    connectionLost = () => {
+        const { vocabulary, showNotificationAction } = this.props;
+        const { v_connection_problem } = vocabulary;
+        showNotificationAction({
+            type: 'lost-connection',
+            text: v_connection_problem,
+        });
+    };
+
     componentDidMount() {
         this.setResponsiveReducer();
         addEvent(window, 'resize', this.setResponsiveReducer);
+        window.addEventListener('online', this.connectionRestore);
+        window.addEventListener('offline', this.connectionLost);
     }
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.setResponsiveReducer);
+        window.removeEventListener('online', this.connectionRestore);
+        window.removeEventListener('offline', this.connectionLost);
     }
 
     render() {
@@ -106,10 +129,12 @@ class App extends Component {
 
 const mapStateToProps = state => ({
     isMobile: state.responsiveReducer.isMobile,
+    vocabulary: state.languageReducer.vocabulary,
 });
 
 const mapDispatchToProps = {
     ...responsiveActions,
+    showNotificationAction,
 };
 
 export default withRouter(

--- a/project/application/src/components/ModalInfo/index.js
+++ b/project/application/src/components/ModalInfo/index.js
@@ -90,6 +90,11 @@ const TeamSwitchedIcon = () => (
 );
 
 class ModalInfo extends Component {
+    constructor(props) {
+        super(props);
+        this.removeNotification = this.closeNotificationTimeOut.bind(this);
+        this.hideModalInfoInTime = this.hideModalInfo.bind(this);
+    }
     componentDidMount() {
         window.addEventListener('online', this.connectionRestore);
         window.addEventListener('offline', this.connectionLost);
@@ -98,6 +103,7 @@ class ModalInfo extends Component {
     componentWillUnmount() {
         window.removeEventListener('online', this.connectionRestore);
         window.removeEventListener('offline', this.connectionLost);
+        window.removeEventListener('mousemove', this.removeNotification);
     }
 
     connectionRestore = event => {
@@ -133,10 +139,19 @@ class ModalInfo extends Component {
     };
 
     componentDidUpdate(prevProps, prevState) {
-        const { currentTeam } = this.props;
+        const { currentTeam, notificationReducer } = this.props;
+        const { notificationType } = notificationReducer;
         if (prevProps.currentTeam.data.name && currentTeam.data.name !== prevProps.currentTeam.data.name) {
             this.teamSwitched();
         }
+        if (prevProps !== this.props && notificationType) {
+            window.addEventListener('mousemove', this.removeNotification);
+        }
+    }
+
+    closeNotificationTimeOut() {
+        setTimeout(this.hideModalInfoInTime, 2500);
+        window.removeEventListener('mousemove', this.removeNotification);
     }
 
     render() {

--- a/project/application/src/components/PageTemplate/index.js
+++ b/project/application/src/components/PageTemplate/index.js
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 
 // actions
 import { switchMenu } from '../../actions/ResponsiveActions';
+import { showNotificationAction } from '../../actions/NotificationActions';
 
 // components
 import LeftBar from '../../components/LeftBar';
@@ -17,6 +18,22 @@ import ModalInfo from '../../components/ModalInfo';
 import './style.scss';
 
 class PageTemplate extends Component {
+    teamSwitched = () => {
+        const { currentTeam, vocabulary, showNotificationAction } = this.props;
+        const { v_switch_team_to_the } = vocabulary;
+        showNotificationAction({
+            type: 'team-switched',
+            text: `${v_switch_team_to_the} ${currentTeam.data.name}`,
+        });
+    };
+
+    componentDidUpdate(prevProps) {
+        const { currentTeam } = this.props;
+        if (prevProps.currentTeam.data.name && currentTeam.data.name !== prevProps.currentTeam.data.name) {
+            this.teamSwitched();
+        }
+    }
+
     render() {
         const {
             content: Content,
@@ -27,6 +44,7 @@ class PageTemplate extends Component {
             hideSidebar,
             hideHeader,
             viewport,
+            notificationId,
         } = this.props;
         const { width, height } = viewport;
 
@@ -38,7 +56,7 @@ class PageTemplate extends Component {
                             <Header />
                         </header>
                     )}
-                <ModalInfo />
+                {notificationId.length ? <ModalInfo /> : null}
                 <div className="wrapper-main-content">
                     {!hideSidebar && (
                         <aside
@@ -69,10 +87,13 @@ const mapStateToProps = state => ({
     isShowMenu: state.responsiveReducer.isShowMenu,
     isMobile: state.responsiveReducer.isMobile,
     vocabulary: state.languageReducer.vocabulary,
+    notificationId: state.notificationReducer.notificationId,
+    currentTeam: state.teamReducer.currentTeam,
 });
 
 const mapDispatchToProps = {
     switchMenu,
+    showNotificationAction,
 };
 
 export default withRouter(

--- a/project/application/src/reducers/NotificationReducer.js
+++ b/project/application/src/reducers/NotificationReducer.js
@@ -1,9 +1,12 @@
 import { SHOW_NOTIFICATION, HIDE_NOTIFICATION } from '../actions/NotificationActions';
 import { RESET_ALL } from '../actions/UserActions';
 
+const uuidv4 = require('uuid/v4');
+
 const initialState = {
     notificationText: '',
     notificationType: null,
+    notificationId: '',
 };
 
 export default (state = initialState, { type, payload }) => {
@@ -12,6 +15,7 @@ export default (state = initialState, { type, payload }) => {
             return {
                 notificationText: payload.text,
                 notificationType: payload.type,
+                notificationId: uuidv4(),
             };
         case HIDE_NOTIFICATION:
             return initialState;


### PR DESCRIPTION
Reworked ModalInfo component now it show's and hide's, not always on pageTemplate
Creating notification now creates listener on mousemove which starts timeout for notification window close. If new notification shows while timeout is on it stops current timeout and creates knew listener
Moved online/offline listeners to App
Moved team switch listeners to PageTemplate  